### PR TITLE
Run cleanup job every 2 hours

### DIFF
--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -58,7 +58,7 @@ objects:
         app: thoth
         component: cleanup
     spec:
-      schedule: "@daily"
+      schedule: "0 */2 * * *"
       suspend: ${{SUSPEND_JOB}}
       successfulJobsHistoryLimit: 1
       failedJobsHistoryLimit: 2


### PR DESCRIPTION
As solver jobs have set ttl to 2 hours, let's run cleanup job more often. This
way we will clean up the cluster faster and we will reduce pressure on
OpenShift's API.