### PR TITLE
Lower cleanup TTL to 2 hours by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ This periodic job (CronJob) queries Jobs, ImageStreams, ConfigMaps and BuildConf
 * using `THOTH_CLEANUP_DEFAULT_TTL` environment variable provided to the thoth-cleanup CronJob deployment
 * in the label under the `ttl` key - for example in the job spec label `ttl=5d` means "delete the given job after 5 days" - this overrides the above configuration option
 
-If there is no ttl set in the resourse labels and there is no `THOTH_CLEANUP_DEFAULT_TTL` set in the deployement, the TTL configuration defaults to 7 days.
+If there is no ttl set in the resourse labels and there is no `THOTH_CLEANUP_DEFAULT_TTL` set in the deployement, the TTL configuration defaults to 2 hours.
 
 Running cleanup-job locally
 ===========================

--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ init_logging()
 
 
 _LOGGER = logging.getLogger("thoth.cleanup_job")
-_DEFAULT_TTL = parse_ttl(os.getenv("THOTH_CLEANUP_DEFAULT_TTL") or "7d")
+_DEFAULT_TTL = parse_ttl(os.getenv("THOTH_CLEANUP_DEFAULT_TTL") or "2h")
 _CLEANUP_LABEL_SELECTOR = "mark=cleanup"
 _PROMETHEUS_REGISTRY = CollectorRegistry()
 _THOTH_METRICS_PUSHGATEWAY_URL = os.getenv("PROMETHEUS_PUSHGATEWAY_URL")

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -86,6 +86,8 @@ objects:
                       value: "INFO"
                     - name: THOTH_CLEANUP_NAMESPACE
                       value: "${CLEANUP_PROJECT_NAME}"
+                    - name: THOTH_CLEANUP_DEFAULT_TTL
+                      value: "2h"
                     - name: PROMETHEUS_PUSHGATEWAY_URL
                       valueFrom:
                         configMapKeyRef:


### PR DESCRIPTION
* expose TTL environment variable configuration in the template
* lower TTL to 2 hours so old objects are deleted after 2 hours