### PR TITLE
Increase memory requests needed for cronjob

### DIFF
--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     description: "This is Thoth Core - Cleanup Job"
     openshift.io/display-name: "Thoth: Cleanup Job"
-    version: 0.9.0
+    version: 0.9.1
     tags: thoth,ai-stacks,aistacks,thoth-ops
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
       This template defines resources needed to deploy Thoth Cleanup Job to OpenShift.
     template.openshift.io/provider-display-name: "Red Hat, Inc."
-    thoth-station.ninja/template-version: 0.9.0
+    thoth-station.ninja/template-version: 0.9.1
   labels:
     template: cleanup-cronjob
     app: thoth
@@ -57,7 +57,7 @@ objects:
     metadata:
       name: "cleanup-${CLEANUP_PROJECT_NAME}"
       annotations:
-        thoth-station.ninja/template-version: 0.9.0
+        thoth-station.ninja/template-version: 0.9.1
       labels:
         app: thoth
         component: cleanup
@@ -105,10 +105,10 @@ objects:
                           name: thoth
                   resources:
                     requests:
-                      memory: "256Mi"
+                      memory: "512Mi"
                       cpu: "500m"
                     limits:
-                      memory: "256Mi"
+                      memory: "512Mi"
                       cpu: "500m"
                   livenessProbe:
                     failureThreshold: 1


### PR DESCRIPTION
I observed few OOM kills when there is a lot to clean. Increase memory requests.